### PR TITLE
@W-15815139: Add beta labels and update readme to use Salesforce CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,14 @@
 # Title
 
-This repo contains sample catalog items for Einstein Copilot.
+This repository contains sample catalog items for Einstein Copilot.
 
 ## Installation
 
-Install the Service Catalog Copilot metadata with `sf` CLI, or using this button.
+### Use Salesforce CLI
 
-<a href="https://githubsfdeploy.herokuapp.com?owner=salesforce&amp;repo=service-catalog-copilot">
-  <img src="https://raw.githubusercontent.com/afawcett/githubsfdeploy/master/src/main/webapp/resources/img/deploy.png" alt="Deploy to Salesforce" />
-</a>
+1. Install [Salesforce CLI](https://developer.salesforce.com/tools/salesforcecli)
+2. Connect Salesforce CLI to your org: 
+* `sf org login web --alias yourOrgAlias --instance-url https://yourOrg.sandbox.my.salesforce.com` 
+* Use domain URL found in Setup > Company Settings > My Domain
+3. Deploy Service Catalog Copilot metadata: 
+* `sf project deploy start --source-dir force-app --target-org yourOrgAlias`

--- a/force-app/main/default/svcCatalogItems/item_1697538605288_UpdateEmailAddress.catalogItem-meta.xml
+++ b/force-app/main/default/svcCatalogItems/item_1697538605288_UpdateEmailAddress.catalogItem-meta.xml
@@ -21,6 +21,6 @@
     </inputs>
     <isFeatured>false</isFeatured>
     <isProtected>false</isProtected>
-    <masterLabel>Update Email Address</masterLabel>
+    <masterLabel>Update Email Address (Beta)</masterLabel>
     <status>Published</status>
 </SvcCatalogItemDef>

--- a/force-app/main/default/svcCatalogItems/item_1697539347322_GetHelp.catalogItem-meta.xml
+++ b/force-app/main/default/svcCatalogItems/item_1697539347322_GetHelp.catalogItem-meta.xml
@@ -21,6 +21,6 @@
     </inputs>
     <isFeatured>false</isFeatured>
     <isProtected>false</isProtected>
-    <masterLabel>Get Help</masterLabel>
+    <masterLabel>Get Help (Beta)</masterLabel>
     <status>Published</status>
 </SvcCatalogItemDef>

--- a/force-app/main/default/svcCatalogItems/item_1697543605169_UpdatePhoneNumber.catalogItem-meta.xml
+++ b/force-app/main/default/svcCatalogItems/item_1697543605169_UpdatePhoneNumber.catalogItem-meta.xml
@@ -21,6 +21,6 @@
     </inputs>
     <isFeatured>false</isFeatured>
     <isProtected>false</isProtected>
-    <masterLabel>Update Phone Number</masterLabel>
+    <masterLabel>Update Phone Number (Beta)</masterLabel>
     <status>Published</status>
 </SvcCatalogItemDef>


### PR DESCRIPTION
Salesforce Button is not usable, so I have decided to remove it from the README.MD file.
Instead, I have added a section to deploy Service Catalog Copilot metadata with Salesforce CLI.